### PR TITLE
Add close method to MemoryStore

### DIFF
--- a/src/memorystore.ts
+++ b/src/memorystore.ts
@@ -31,6 +31,9 @@ export default class MemoryStore implements SessionStore {
    */
   store: Map<string, SessionData>;
 
+  /** Stores the timeout ID for the garbage collector */
+  timeoutId: NodeJS.Timeout | null = null;
+
   constructor() {
 
     this.store = new Map();
@@ -96,11 +99,20 @@ export default class MemoryStore implements SessionStore {
    */
   scheduleGc(interval = 600) {
 
-    setTimeout(() => {
+    this.timeoutId = setTimeout(() => {
       this.gc();
       this.scheduleGc(interval);
     }, interval * 1000);
 
+  }
+
+  /**
+   * Cancels the garbage collection scheduler
+   */
+  close() {
+    if (this.timeoutId !== null) {
+      clearTimeout(this.timeoutId);
+    }
   }
 
 }

--- a/test/memorystore.ts
+++ b/test/memorystore.ts
@@ -74,4 +74,39 @@ describe('MemoryStore', () => {
 
   });
 
+  it('should close the GC scheduler', async function() {
+
+    this.timeout(5000);
+
+    const ms = new MemoryStore();
+
+    // GC schedule
+    ms.scheduleGc(1);
+
+    // Before
+    expect(ms.store.get('foo')).to.not.equal(null);
+
+    // Wait 2 seconds
+    await (new Promise(res => {
+      setTimeout(res, 2000);
+    }));
+
+    // After GC run
+    expect(ms.store.get('foo')).to.equal(undefined);
+
+    ms.close();
+
+    // Before
+    expect(ms.store.get('bar')).to.not.equal(null);
+
+    // Wait 2 seconds
+    await (new Promise(res => {
+      setTimeout(res, 2000);
+    }));
+
+    // After GC run
+    expect(ms.store.get('bar')).to.not.equal(null);
+
+  });
+
 });


### PR DESCRIPTION
When writing tests downstream of a curveball application with the `session`  installed, the tail-calling timeout in `MemoryStore` is considered an "open hook" that won't allow `jest` to exit cleanly.

This PR adds a `MemoryStore.close()` method to disable the GC timer.

The idea here is that it can be cleaned up in the `afterAll` jest hook, allowing jest to exit.

```js
afterAll(() => {
  memoryStore.close();
});
```