### PR TITLE
Use canonical CookieOptions type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { CookieSerializeOptions } from 'cookie';
+
 export type SessionOptions = {
 
   store: SessionStore | 'memory';
@@ -6,14 +8,7 @@ export type SessionOptions = {
   cookieOptions?: CookieOptions;
 };
 
-export type CookieOptions = {
-  domain?: string;
-  expires?: Date;
-  httpOnly?: boolean;
-  path?: string;
-  secure?: boolean;
-  sameSite: boolean | 'strict' | 'none' | 'lax';
-};
+export type CookieOptions = CookieSerializeOptions;
 
 export type SessionValues = {
   [s: string]: any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,10 +5,8 @@ export type SessionOptions = {
   store: SessionStore | 'memory';
   cookieName?: string;
   expiry?: number;
-  cookieOptions?: CookieOptions;
+  cookieOptions?: CookieSerializeOptions;
 };
-
-export type CookieOptions = CookieSerializeOptions;
 
 export type SessionValues = {
   [s: string]: any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,18 @@
-import { CookieSerializeOptions } from 'cookie';
-
 export type SessionOptions = {
 
   store: SessionStore | 'memory';
   cookieName?: string;
   expiry?: number;
-  cookieOptions?: CookieSerializeOptions;
+  cookieOptions?: CookieOptions;
+};
+
+export type CookieOptions = {
+  domain?: string;
+  httpOnly?: boolean;
+  maxAge?: number;
+  path?: string;
+  secure?: boolean;
+  sameSite: boolean | 'strict' | 'none' | 'lax';
 };
 
 export type SessionValues = {


### PR DESCRIPTION
We recently ran into an issue with OrderUp. We were passing a `Date` directly to `cookieOptions.expires`. However, this only runs when the middleware is initialized, so 4 hours after we deployed all the cookies had an expiry in the past.

To address this, I wanted to move to `Max-Age` instead of `Expires`. I could see that it was supported by the underlaying `cookie` package, but was missing in the `@curveball/session` `CookieOptions` type. I was able to hotfix our session problem by forcing the type. https://github.com/ordrup/ou-api/pull/868#discussion_r903017558

This PR uses the `CookieSerializeOptions` type directly from the `cookie` package, since the value is passed through transparently.

It may potentially be wise to remove the `expires` option altogether, since I'm not sure how you could possibly use it without generated the bug I mentioned above. That's a breaking change though, so I've left it out. LMK if you'd like me to make that change as well.

