### PR TITLE
Still store session data and send cookie if other middlewares throw

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "typescript": "^4.2.2"
       },
       "peerDependencies": {
-        "@curveball/kernel": "^0.20.0"
+        "@curveball/kernel": ">=0.20.0 <1"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "prepublishOnly": "make build",
-    "test": "make lint test",
+    "test": "make test",
     "lint": "make lint",
     "tsc": "tsc"
   },

--- a/src/mw.ts
+++ b/src/mw.ts
@@ -76,37 +76,43 @@ export default function(options: SessionOptions): Middleware {
 
     }
 
-    // Run all middlewares
-    await next();
+    try {
 
-    if (sessionId && !ctx.sessionId) {
-      // The session id was removed from the context, wipe out old session.
-      await store.delete(sessionId);
-    }
+      // Run all middlewares
+      await next();
 
-    const hasData = ctx.session && Object.keys(ctx.session).length > 0;
+    } finally { 
 
-    if (sessionId && !hasData) {
-
-      // There was a session, but there's no session data anymore. We remove
-      // the session
-      await store.delete(sessionId);
-
-    } else if (hasData) {
-
-      if (!ctx.sessionId) {
-
-        // Create a new session id.
-        sessionId = await store.newSessionId();
-
+      if (sessionId && !ctx.sessionId) {
+        // The session id was removed from the context, wipe out old session.
+        await store.delete(sessionId);
       }
 
-      await store.set(sessionId!, ctx.session, Math.floor(Date.now() / 1000) + expiry);
+      const hasData = ctx.session && Object.keys(ctx.session).length > 0;
 
-      // Send new cookie
-      ctx.response.headers.set('Set-Cookie',
-        cookie.serialize(cookieName, sessionId!, cookieOptions)
-      );
+      if (sessionId && !hasData) {
+
+        // There was a session, but there's no session data anymore. We remove
+        // the session
+        await store.delete(sessionId);
+
+      } else if (hasData) {
+
+        if (!ctx.sessionId) {
+
+          // Create a new session id.
+          sessionId = await store.newSessionId();
+
+        }
+
+        await store.set(sessionId!, ctx.session, Math.floor(Date.now() / 1000) + expiry);
+
+        // Send new cookie
+        ctx.response.headers.set('Set-Cookie',
+          cookie.serialize(cookieName, sessionId!, cookieOptions)
+        );
+
+      }
 
     }
 

--- a/src/mw.ts
+++ b/src/mw.ts
@@ -81,7 +81,7 @@ export default function(options: SessionOptions): Middleware {
       // Run all middlewares
       await next();
 
-    } finally { 
+    } finally {
 
       if (sessionId && !ctx.sessionId) {
         // The session id was removed from the context, wipe out old session.


### PR DESCRIPTION
If a middleware throws an error, and that error does not get caught before entering back into the session middleware, cookies were not sent and session data was not stored.

This can happen if users have a 'problem' (error handling) middleware before the session middleware. Errors bubble right up.

Using try...finally we can ensure that the session storing mechanism always worked, regardless of if `await next()` threw an error or not.

The included test-case failed before this change, but passes after this change.