### PR TITLE
fix: typo in code example for session deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ To delete an open session, just clear the session data:
 ```typescript
 app.use( ctx => {
 
-  // Running this will create the session
-  ctx.session = null;
+  // Running this will delete the session
+  ctx.session = {};
 
 });
 ```


### PR DESCRIPTION
This PR fixes the `Deleting a session` example in the README where the code example appears to be wrong.